### PR TITLE
Add required permissions to scorecard.yml

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
+      id-token: write
       actions: read
       contents: read
 


### PR DESCRIPTION
scorecard-action will always fail due to v2 update changing tokenstore, but not updating permissions. This PR will rectify this via granting it those token-write permissions.